### PR TITLE
reject promise on bad request

### DIFF
--- a/lib/API_v1_0.js
+++ b/lib/API_v1_0.js
@@ -236,7 +236,7 @@ API_v1_0.prototype.getData = function(league, season, feed, format, params) {
 
       deferred.resolve(data);
     } else {
-      throw new Error("API call failed with error: " + err.statusCode);
+      deferred.reject(new Error("API call failed with error: " + err.statusCode));
     }
   }.bind(this));
 


### PR DESCRIPTION
When making a call to retrieve the full game schedule (I was specifically getting NBA information), if the date was either beyond the possible date range (e.g. October 2018) or there weren't any games on that date, it would error and return a 400. However, it was saying that there wasn't an unhandled rejection error:
`Unhandled rejection Error: API call failed with error: 400
    at API_v1_2.<anonymous> (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/mysportsfeeds-node/lib/API_v1_0.js:240:13)
    at tryCatcher (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/promise.js:689:18)
    at Async._drainQueue (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/evanteague/Documents/Projects/nbastats/stats-backend/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)`

I believe this is because on this line https://github.com/MySportsFeeds/mysportsfeeds-node/blob/master/lib/API_v1_0.js#L239 it's not rejecting the promise, so my error handling couldn't check anything. I had 0 experience with the Q library and using "deferred," but rejecting the deferred seemed to make everything work.