### PR TITLE
Updated to add daily_odds_gamelines

### DIFF
--- a/lib/API_v2_0.js
+++ b/lib/API_v2_0.js
@@ -10,6 +10,7 @@ var API_v2_0 = function(v, storeT, storeL) {
   this.validFeeds = [
 	  'seasonal_games',
     'daily_games',
+    'daily_odds_gamelines'
     'weekly_games',
     'seasonal_dfs',
     'daily_dfs',
@@ -53,6 +54,16 @@ API_v2_0.prototype.__determineUrl = function(league, season, feed, format, param
     }
 
     return this.baseUrl + '/' + league + '/' + season + '/date/' + params['date'] + '/games.' + format;
+
+  } else if ( feed == "daily_odds_gamelines" ) {
+    if ( !season ) {
+	  throw new Error("You must specify a season for this request.");
+	}
+    if ( !Object.keys(params).includes("date") ) {
+      throw new Error("You must specify a 'date' param for this request.");
+    }
+
+    return this.baseUrl + '/' + league + '/' + season + '/date/' + params['date'] + '/odds_gamelines.' + format;
 
   } else if ( feed == "weekly_games" ) {
     if ( !season ) {


### PR DESCRIPTION
Modified `API_v2_0.js` to support the `daily_odds_gamelines` for json and xml from https://www.mysportsfeeds.com/data-feeds/api-docs/. 

Example url output: 
https://api.mysportsfeeds.com/v2.0/pull/nba/2018-2019-regular/date/20181213/odds_gamelines.json