### PR TITLE
Missed a comma

### DIFF
--- a/lib/API_v2_0.js
+++ b/lib/API_v2_0.js
@@ -10,7 +10,7 @@ var API_v2_0 = function(v, storeT, storeL) {
   this.validFeeds = [
 	  'seasonal_games',
     'daily_games',
-    'daily_odds_gamelines'
+    'daily_odds_gamelines',
     'weekly_games',
     'seasonal_dfs',
     'daily_dfs',


### PR DESCRIPTION
My mistake – left out a comma when adding 'daily_odds_gamelines' feed. 